### PR TITLE
chore: remove redundant ex_doc reference

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.13-alpine
+FROM elixir:1.18.3-otp-26-alpine
 
 WORKDIR /app
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,7 @@ defmodule CredoJenkins.MixProject do
   defp deps do
     [
       {:jason, "~> 1.3"},
-      {:credo, "~> 1.6"},
-      {:ex_doc, "~> 0.28.0"}
+      {:credo, "~> 1.6"}
     ]
   end
 end


### PR DESCRIPTION
We are not using ex_doc in this project and the fixation to version 0.28.x caused problems when trying to upgrade ex_doc in other projects using this one.

Ref: https://linear.app/vitalbeats/issue/VB-2246/upgrade-elixir-projects-to-v118x